### PR TITLE
update oauth paths, example tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,17 +58,17 @@ The app must have an endpoint registered with SwiftID to use as a webhook callba
 
 POST your client credentials to the OAuth endpoint:
 ```
-curl -X POST https://api-sandbox.capitalone.com/oauth/oauth20/token\
+curl -X POST https://api-sandbox.capitalone.com/oauth2/token\
      -d 'client_id=<client_id>'\
      -d 'client_secret=<client_secret>'\
      -d 'grant_type=client_credentials'
 ```
-The response will contain an access token:
+The response will contain an access token. Note that the token is larger than shown here:
 ```
 HTTP/1.1 200 OK
 Content-Type: application/json
     {
-        "access_token" : "5354e3a56036056cffb5a99f368a31cef3aee2a8",
+        "access_token" : "eyJlbmMiOiJBMTI4Q0JDX0hTMjU2IiwicGNrIjoxLCJhbGciOiJESVIiLCJraWQiOiJhN3EifQ..8Xjh0FxH6cSUAtY5LiZbTg....",
         "token_type" : "Bearer",
         "expires_in" : 1295999
     }

--- a/config.js
+++ b/config.js
@@ -25,8 +25,8 @@ module.exports = {
       apiVersion: 1
     },
     oauth: {
-      authorizationURL: oauthHost + '/oauth/auz/authorize',
-      tokenURL: oauthHost + '/oauth/oauth20/token',
+      authorizationURL: oauthHost + '/oauth2/authorize',
+      tokenURL: oauthHost + '/oauth2/token',
       // The clientId and clientSecret you received when registering your app.
       clientID: process.env.SWIFTID_CLIENT_ID,
       clientSecret: process.env.SWIFTID_CLIENT_SECRET,

--- a/views/login.jade
+++ b/views/login.jade
@@ -39,18 +39,18 @@ block content
   p POST your client credentials to the OAuth endpoint:
   pre
     code
-      | curl -X POST https://api-sandbox.capitalone.com/oauth/oauth20/token \
+      | curl -X POST https://api-sandbox.capitalone.com/oauth2/token \
       |      -d 'client_id=&lt;client_id&gt;'\
       |      -d 'client_secret=&lt;client_secret&gt;'\
       |      -d 'grant_type=client_credentials'
 
-  p The response will contain an access token:
+  p The response will contain an access token. Note that the token is larger than shown here:
   pre
     code
       | HTTP/1.1 200 OK
       | Content-Type: application/json
       |    {
-      |        "access_token" : "5354e3a56036056cffb5a99f368a31cef3aee2a8",
+      |        "access_token" : "eyJlbmMiOiJBMTI4Q0JDX0hTMjU2IiwicGNrIjoxLCJhbGciOiJESVIiLCJraWQiOiJhN3EifQ..8Xjh0FxH6cSUAtY5LiZbTg....",
       |        "token_type" : "Bearer",
       |        "expires_in" : 1295999
       |    }


### PR DESCRIPTION
These updates are, like the openid scope, to accommodate changes in the authorization server for the December release. No rush to merge.